### PR TITLE
Typography control update and fixed missing `=` in search form

### DIFF
--- a/inc/class-cream-magazine.php
+++ b/inc/class-cream-magazine.php
@@ -543,7 +543,7 @@ class Cream_Magazine {
 	 */
 	public function search_form( $form ) {
 
-		$form = '<form role="search" class="cm-search-form" method="get" action="' . esc_url( home_url( '/' ) ) . '"><input type="search" name="s" placeholder="' . esc_attr__( 'Type Here', 'cream-magazine' ) . '" value"' . get_search_query() . '" ><button type="submit" class="cm-submit-btn"><i class="feather icon-search"></i></button></form>';
+		$form = '<form role="search" class="cm-search-form" method="get" action="' . esc_url( home_url( '/' ) ) . '"><input type="search" name="s" placeholder="' . esc_attr__( 'Type Here', 'cream-magazine' ) . '" value="' . get_search_query() . '" ><button type="submit" class="cm-submit-btn"><i class="feather icon-search"></i></button></form>';
 
 		return $form;
 	}

--- a/inc/customizer/controls/typography/class-cream-magazine-customize-typography-control.php
+++ b/inc/customizer/controls/typography/class-cream-magazine-customize-typography-control.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'WP_Customize_Control' ) ) {
 /**
  * Custom Customize Typography Control.
  *
- * @since 1.0.2
+ * @since 2.1.2
  */
 class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 
@@ -112,7 +112,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 			'slimselect',
 			$select_asset_uri . 'css/slimselect.css',
 			null,
-			CREAM_MAGAZINE_VERSION,
+			'2.0.2',
 			'all'
 		);
 
@@ -128,7 +128,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 			'slimselect',
 			$select_asset_uri . 'js/slimselect.min.js',
 			null,
-			CREAM_MAGAZINE_VERSION,
+			'2.0.2',
 			true
 		);
 
@@ -150,8 +150,11 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 
 		parent::to_json();
 
-		$setting_value              = ( $this->value() ) ? $this->value() : $this->setting->default;
-		$json_decoded_setting_value = json_decode( $setting_value, true );
+		$setting_value                = ( $this->value() ) ? $this->value() : $this->setting->default;
+		$json_decoded_setting_default = json_decode( $this->setting->default, true );
+		$json_decoded_setting_value   = json_decode( $setting_value, true );
+
+		$setting_value = wp_json_encode( cream_magazine_recursive_parse_args( $json_decoded_setting_value, $json_decoded_setting_default ) );
 
 		$this->json['id']                 = $this->id;
 		$this->json['label']              = $this->label;
@@ -358,6 +361,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let desktopFontSize = ( savedValue.font_sizes.desktop.value ) ? savedValue.font_sizes.desktop.value : defaultValue.font_sizes.desktop.value;
 										let desktopFontSizeUnit = ( savedValue.font_sizes.desktop.unit ) ? savedValue.font_sizes.desktop.unit : defaultValue.font_sizes.desktop.unit;
+										let isDesktopFontSizeUnitChangeable = ( savedValue.font_sizes.desktop.unit_changeable ) ? savedValue.font_sizes.desktop.unit_changeable : defaultValue.font_sizes.desktop.unit_changeable;
 										#>
 										<input
 											{{{ data.fontSizeInputAttrs }}}
@@ -376,6 +380,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-desktop-font-size-unit-{{ data.id }}"
 												id="cream-magazine-desktop-font-size-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isDesktopFontSizeUnitChangeable }}"
 											>
 												<span>{{ desktopFontSizeUnit }}</span>
 												<input
@@ -415,6 +420,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let tabletFontSize = ( savedValue.font_sizes.tablet.value ) ? savedValue.font_sizes.tablet.value : defaultValue.font_sizes.tablet.value;
 										let tabletFontSizeUnit = ( savedValue.font_sizes.tablet.unit ) ? savedValue.font_sizes.tablet.unit : defaultValue.font_sizes.tablet.unit;
+										let isTabletFontSizeUnitChangeable = ( savedValue.font_sizes.tablet.unit_changeable ) ? savedValue.font_sizes.tablet.unit_changeable : defaultValue.font_sizes.tablet.unit_changeable;
 										#>
 										<input 
 											{{{ data.fontSizeInputAttrs }}}	
@@ -433,6 +439,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-tablet-font-size-unit-{{ data.id }}"
 												id="cream-magazine-tablet-font-size-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isTabletFontSizeUnitChangeable }}"
 											>
 												<span>{{ tabletFontSizeUnit }}</span>
 												<input
@@ -472,6 +479,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let mobileFontSize = ( savedValue.font_sizes.mobile.value ) ? savedValue.font_sizes.mobile.value : defaultValue.font_sizes.mobile.value;
 										let mobileFontSizeUnit = ( savedValue.font_sizes.mobile.unit ) ? savedValue.font_sizes.mobile.unit : defaultValue.font_sizes.mobile.unit;
+										let isMobileFontSizeUnitChangeable = ( savedValue.font_sizes.mobile.unit_changeable ) ? savedValue.font_sizes.mobile.unit_changeable : defaultValue.font_sizes.mobile.unit_changeable;
 										#>
 										<input
 											{{{ data.fontSizeInputAttrs }}}
@@ -490,6 +498,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-mobile-font-size-unit-{{ data.id }}"
 												id="cream-magazine-mobile-font-size-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isMobileFontSizeUnitChangeable }}"
 											>
 												<span>{{ mobileFontSizeUnit }}</span>
 												<input
@@ -531,6 +540,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let normalFontSize = ( savedValue.font_size.value ) ? savedValue.font_size.value : defaultValue.font_size.value;
 										let normalFontSizeUnit = ( savedValue.font_size.unit ) ? savedValue.font_size.unit : defaultValue.font_size.unit;
+										let isNormalFontSizeUnitChangeable = ( savedValue.font_size.unit_changeable ) ? savedValue.font_size.unit_changeable : defaultValue.font_size.unit_changeable;
 										#>
 										<input
 											{{{ data.fontSizeInputAttrs }}}
@@ -549,6 +559,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-desktop-font-size-unit-{{ data.id }}"
 												id="cream-magazine-desktop-font-size-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isNormalFontSizeUnitChangeable }}"
 											>
 												<span>{{ normalFontSizeUnit }}</span>
 												<input
@@ -716,6 +727,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let desktopLetterSpacing = ( savedValue.letter_spacings.desktop.value ) ? savedValue.letter_spacings.desktop.value : defaultValue.letter_spacings.desktop.value;
 										let desktopLetterSpacingUnit = ( savedValue.letter_spacings.desktop.unit ) ? savedValue.letter_spacings.desktop.unit : defaultValue.letter_spacings.desktop.unit;
+										let isDesktopLetterSpacingUnitChangeable = ( savedValue.letter_spacings.desktop.unit_changeable ) ? savedValue.letter_spacings.desktop.unit_changeable : defaultValue.letter_spacings.desktop.unit_changeable;
 										#>
 										<input
 											{{{ data.letterSpacingInputAttrs }}}
@@ -734,6 +746,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-desktop-letter-spacing-unit-{{ data.id }}"
 												id="cream-magazine-desktop-letter-spacing-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isDesktopLetterSpacingUnitChangeable }}"
 											>
 												<span>{{ desktopLetterSpacingUnit }}</span>
 												<input
@@ -773,6 +786,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let tabletLetterSpacing = ( savedValue.letter_spacings.tablet.value ) ? savedValue.letter_spacings.tablet.value : defaultValue.letter_spacings.tablet.value;
 										let tabletLetterSpacingUnit = ( savedValue.letter_spacings.tablet.unit ) ? savedValue.letter_spacings.tablet.unit : defaultValue.letter_spacings.tablet.unit;
+										let isTabletLetterSpacingUnitChangeable = ( savedValue.letter_spacings.tablet.unit_changeable ) ? savedValue.letter_spacings.tablet.unit_changeable : defaultValue.letter_spacings.tablet.unit_changeable;
 										#>
 										<input
 											{{{ data.letterSpacingInputAttrs }}}
@@ -792,6 +806,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												id="cream-magazine-tablet-letter-spacing-unit-{{ data.id }}"
 												value="{{ tabletLetterSpacingUnit }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isTabletLetterSpacingUnitChangeable }}"
 											>
 												<span>{{ tabletLetterSpacingUnit }}</span>
 												<input
@@ -830,6 +845,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let mobileLetterSpacing = ( savedValue.letter_spacings.mobile.value ) ? savedValue.letter_spacings.mobile.value : defaultValue.letter_spacings.mobile.value;
 										let mobileLetterSpacingUnit = ( savedValue.letter_spacings.mobile.unit ) ? savedValue.letter_spacings.mobile.unit : defaultValue.letter_spacings.mobile.unit;
+										let isMobileLetterSpacingUnitChangeable = ( savedValue.letter_spacings.mobile.unit_changeable ) ? savedValue.letter_spacings.mobile.unit_changeable : defaultValue.letter_spacings.mobile.unit_changeable;
 										#>
 										<input
 											{{{ data.letterSpacingInputAttrs }}}
@@ -848,6 +864,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-mobile-letter-spacing-unit-{{ data.id }}"
 												id="cream-magazine-mobile-letter-spacing-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isMobileLetterSpacingUnitChangeable }}"
 											>
 												<span>{{ mobileLetterSpacingUnit }}</span>
 												<input
@@ -889,6 +906,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 										<#
 										let normalLetterSpacing = ( savedValue.letter_spacing.value ) ? savedValue.letter_spacing.value : defaultValue.letter_spacing.value;
 										let normalLetterSpacingUnit = ( savedValue.letter_spacing.unit ) ? savedValue.letter_spacing.unit : defaultValue.letter_spacing.unit;
+										let isNormalLetterSpacingUnitChangeable = ( savedValue.letter_spacing.unit_changeable ) ? savedValue.letter_spacing.unit_changeable : defaultValue.letter_spacing.unit_changeable;
 										#>
 										<input
 											{{{ data.letterSpacingInputAttrs }}}
@@ -907,6 +925,7 @@ class Cream_Magazine_Customize_Typography_Control extends WP_Customize_Control {
 												name="cream-magazine-normal-letter-spacing-unit-{{ data.id }}"
 												id="cream-magazine-normal-letter-spacing-unit-{{ data.id }}"
 												data-control="{{ data.id }}"
+												data-changeable="{{ isNormalLetterSpacingUnitChangeable }}"
 											>
 												<span>{{ normalLetterSpacingUnit }}</span>
 												<input

--- a/inc/customizer/controls/typography/typography.js
+++ b/inc/customizer/controls/typography/typography.js
@@ -100,7 +100,7 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
             let fontVariantsArray = (fontVariantsSelectEleVal.length > 0) ? fontVariantsSelectEleVal : control.params.defaultFontWeights;
             let uniqueFontVariants = [];
 
-            if (fontVariantsArray.length > 0 ) {  
+            if (fontVariantsArray.length > 0) {
                 fontVariantsArray.forEach(function (fontVariant) {
                     if (!uniqueFontVariants.includes(parseInt(fontVariant))) {
                         uniqueFontVariants.push(parseInt(fontVariant));
@@ -111,7 +111,7 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
             let fontVariantsOptionsEles = '<option value="inherit" selected>Inherit</option>';
 
             if (uniqueFontVariants.length > 0) {
-                uniqueFontVariants.forEach(function(uniqueFontVariant) {
+                uniqueFontVariants.forEach(function (uniqueFontVariant) {
                     fontVariantsOptionsEles += '<option value="' + uniqueFontVariant + '">' + uniqueFontVariant + '</option>';
                 });
             }
@@ -142,12 +142,12 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
 
             if (uniqueFontVariants.length > 0) {
                 uniqueFontVariants.forEach(function (uniqueFontVariant) {
-                    if ( parseInt( fontWeightSelectEleVal ) === uniqueFontVariant ) {
+                    if (parseInt(fontWeightSelectEleVal) === uniqueFontVariant) {
                         fontVariantsOptionsEles += '<option value="' + uniqueFontVariant + '" selected>' + uniqueFontVariant + '</option>';
                     } else {
                         fontVariantsOptionsEles += '<option value="' + uniqueFontVariant + '">' + uniqueFontVariant + '</option>';
                     }
-                    
+
                 });
             }
 
@@ -183,8 +183,8 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
 
             settingValue.source = fontSource;
             settingValue.font_family = fontFamily;
-            
-            if ( fontSource === 'google' ) {
+
+            if (fontSource === 'google') {
                 fontVariantsSelectEle.val('400');
                 settingValue.font_variants = '400';
 
@@ -272,19 +272,56 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
                 let thisEle = jQuery(this);
                 let settingValue = getSettingValue(control.id);
                 let targetDevice = thisEle.data('device');
-                switch (targetDevice) {
-                    case 'desktop':
-                        settingValue.font_sizes.desktop.unit = thisEle.val();
-                        break;
-                    case 'tablet':
-                        settingValue.font_sizes.tablet.unit = thisEle.val();
-                        break;
-                    case 'mobile':
-                        settingValue.font_sizes.mobile.unit = thisEle.val();
-                        break;
-                    default:
-                        settingValue.font_size.unit = thisEle.val();
+
+                let fontSizeInputEle = jQuery('#cream-magazine-' + targetDevice + '-font-size-' + control.id);
+
+                if (thisEle.val() === 'rem' || thisEle.val() === 'em') {
+                    let fontSizeInputEleVal = fontSizeInputEle.val();
+                    console.log(typeof fontSizeInputEleVal);
+
+                    if (typeof fontSizeInputEleVal === 'string' && fontSizeInputEleVal.includes('.')) {
+                        fontSizeInputEleVal = parseFloat(fontSizeInputEleVal).toFixed(1);
+                    } else {
+                        fontSizeInputEleVal = Number(fontSizeInputEleVal);
+                    }
+
+                    console.log(Number.isInteger(fontSizeInputEleVal));
+                    if (Number.isInteger(fontSizeInputEleVal)) {
+                        fontSizeInputEleVal = parseFloat(fontSizeInputEleVal / 16).toFixed(1);
+                    }
+                    console.log(fontSizeInputEleVal);
+                    fontSizeInputEle.attr('step', '0.1');
+                    fontSizeInputEle.val(fontSizeInputEleVal);
+                } else {
+
+                    let fontSizeInputEleVal = fontSizeInputEle.val();
+
+                    if (typeof fontSizeInputEleVal === 'string' && fontSizeInputEleVal.includes('.')) {
+                        fontSizeInputEleVal = parseFloat(fontSizeInputEleVal).toFixed(1);
+                    } else {
+                        fontSizeInputEleVal = Number(fontSizeInputEleVal);
+                    }
+
+                    fontSizeInputEleVal = parseInt(fontSizeInputEleVal * 16);
+
+                    fontSizeInputEle.attr('step', '1');
+                    fontSizeInputEle.val(fontSizeInputEleVal);
                 }
+
+                if (thisEle.val())
+                    switch (targetDevice) {
+                        case 'desktop':
+                            settingValue.font_sizes.desktop.unit = thisEle.val();
+                            break;
+                        case 'tablet':
+                            settingValue.font_sizes.tablet.unit = thisEle.val();
+                            break;
+                        case 'mobile':
+                            settingValue.font_sizes.mobile.unit = thisEle.val();
+                            break;
+                        default:
+                            settingValue.font_size.unit = thisEle.val();
+                    }
                 saveSetting(control.id, settingValue);
             });
 
@@ -338,6 +375,41 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
                 let thisEle = jQuery(this);
                 let settingValue = getSettingValue(control.id);
                 let targetDevice = thisEle.data('device');
+
+                let letterSpacingInputEle = jQuery('#cream-magazine-' + targetDevice + '-letter-spacing-' + control.id);
+
+                if (thisEle.val() === 'rem' || thisEle.val() === 'em') {
+
+                    let letterSpacingInputEleVal = letterSpacingInputEle.val();
+
+                    if (typeof letterSpacingInputEleVal === 'string' && letterSpacingInputEleVal.includes('.')) {
+                        letterSpacingInputEleVal = parseFloat(letterSpacingInputEleVal).toFixed(1);
+                    } else {
+                        letterSpacingInputEleVal = Number(letterSpacingInputEleVal);
+                    }
+
+                    if (Number.isInteger(letterSpacingInputEleVal)) {
+                        letterSpacingInputEleVal = parseFloat(letterSpacingInputEleVal / 16).toFixed(1);
+                    }
+
+                    letterSpacingInputEle.attr('step', '0.1');
+                    letterSpacingInputEle.val(letterSpacingInputEleVal);
+                } else {
+
+                    let letterSpacingInputEleVal = letterSpacingInputEle.val();
+
+                    if (typeof letterSpacingInputEleVal === 'string' && letterSpacingInputEleVal.includes('.')) {
+                        letterSpacingInputEleVal = parseFloat(letterSpacingInputEleVal).toFixed(1);
+                    } else {
+                        letterSpacingInputEleVal = Number(letterSpacingInputEleVal);
+                    }
+
+                    letterSpacingInputEleVal = parseInt(letterSpacingInputEleVal * 16);
+
+                    letterSpacingInputEle.attr('step', '1');
+                    letterSpacingInputEle.val(letterSpacingInputEleVal);
+                }
+
                 switch (targetDevice) {
                     case 'desktop':
                         settingValue.letter_spacings.desktop.unit = thisEle.val();
@@ -554,7 +626,7 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
 
                     if (italicVariantsCount === 0) {
 
-                        if ( normalVariantsArray[0] !== 400 ) {
+                        if (normalVariantsArray[0] !== 400) {
 
                             fontURL += modifiedFontFamily + ':wght@' + normalVariantsArray[0];
                         } else {
@@ -563,9 +635,9 @@ wp.customize.controlConstructor['cream-magazine-typography'] = wp.customize.Cont
                         }
                     } else if (italicVariantsCount === 1) {
 
-                        if ( italicVariantsArray[0] === 400 ) {
+                        if (italicVariantsArray[0] === 400) {
 
-                            if ( normalVariantsArray[0] !== 400 ) {
+                            if (normalVariantsArray[0] !== 400) {
 
                                 fontURL += modifiedFontFamily + ':ital,wght@0,' + normalVariantsArray[0] + ';1,400';
                             } else {

--- a/inc/helper-functions.php
+++ b/inc/helper-functions.php
@@ -480,3 +480,32 @@ if ( ! function_exists( 'cream_magazine_get_post_taxonomy_select_choices' ) ) {
 		return $select_choices;
 	}
 }
+
+
+if ( ! function_exists( 'cream_magazine_recursive_parse_args' ) ) {
+	/**
+	 * Recursively merge two arrays.
+	 *
+	 * @since 2.1.3
+	 *
+	 * @param array $args Target array.
+	 * @param array $defaults Default array.
+	 */
+	function cream_magazine_recursive_parse_args( $args, $defaults ) {
+
+		$new_args = (array) $defaults;
+
+		foreach ( $args as $key => $value ) {
+
+			if ( is_array( $value ) && isset( $new_args[ $key ] ) ) {
+
+				$new_args[ $key ] = cream_magazine_recursive_parse_args( $value, $new_args[ $key ] );
+			} else {
+
+				$new_args[ $key ] = $value;
+			}
+		}
+
+		return $new_args;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: themebeez
 Requires at least: 5.0.0
 Requires PHP: 5.6
 Tested up to: 6.2
-Stable tag: 2.1.4
+Stable tag: 2.1.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: custom-background, custom-header, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready, one-column, two-columns, blog, news, right-sidebar, theme-options, footer-widgets, left-sidebar, grid-layout, rtl-language-support
@@ -103,6 +103,12 @@ Cream Magazine includes support for Contact Form 7 and Woocommerce.
 
 
 == Changelog ==
+
+= Version 2.1.5 - 2 May, 2023 =
+
+- Fixed:  Missing `=` after an instance of `value` attribute in an `input` tag in `value"' . get_search_query() . '"`.
+- Updated: Typography customize control.
+
 
 = Version 2.1.4 - 11 April, 2023 =
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://themebeez.com/themes/cream-magazine/
 Author: themebeez
 Author URI: https://themebeez.com/
 Description: Cream Magazine is a news & magazine WordPress theme with a clean & modern design suitable for everyone who wish to share their stories, publish a breaking daily news or write on different topics. Everything in Cream Magazine is very easy to deal with, after assigning a front-page one can fully get started to build a website though WordPress Live Customizer.Cream magazine is build taking SEO, Speed & Responsive in mind. Build-in features like lazy load for images has been implemented to make cream mag load faster & extra library files have been bundled to minimize  HTTP requests. For more information go to https://themebeez.com/themes/cream-magazine/
-Version: 2.1.4
+Version: 2.1.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: cream-magazine


### PR DESCRIPTION
- Fixed:  Missing `=` after an instance of `value` attribute in an `input` tag in `value"' . get_search_query() . '"`.
- Updated: Typography customize control.